### PR TITLE
Allow failures on `ruby-head` in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,9 +3,14 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, head]
+        ruby: [2.5, 2.6, 2.7]
+        allow-failures: [false]
+        include:
+          - ruby: head
+            allow-failures: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,4 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 ### New Features
 
 * Initial Release
+
+### Changes
+
+* Allow failures on `ruby-head` in CI
+* Drop support of ruby 2.5 since it's EOLed

--- a/onlyoffice_rake_code_linter.gemspec
+++ b/onlyoffice_rake_code_linter.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = OnlyofficeRakeCodeLinter::NAME
   s.version = OnlyofficeRakeCodeLinter::VERSION
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
   s.authors = ['ONLYOFFICE', 'Pavel Lobashov']
   s.email = %w[shockwavenn@gmail.com]
   s.summary = 'Lib with rake tasks to perform lint on source repos'


### PR DESCRIPTION
From [yesterday](https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11) ruby 2.8 is ruby 3.0 and some gems just
can't install it

Until at least https://github.com/simplecov-ruby/simplecov-html/commit/6567856c6940e285bbb70cce98edca60c7dfefdd2 is released

Also drop support of ruby 2.4 since it's EOLed